### PR TITLE
Add 'GitHub Skills' activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our new partnership and certifications program!",
+        "schedule": "Mondays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This PR adds the new 'GitHub Skills' activity to the list of available activities, as requested in issue #6. Students can now sign up for this new activity and participate in the GitHub certifications program.